### PR TITLE
Use locale instead of hardcoded 24-hour clock

### DIFF
--- a/lib/time-status-view.coffee
+++ b/lib/time-status-view.coffee
@@ -11,7 +11,7 @@ class TimeStatusView extends HTMLElement
   createSpan: ->
     span = document.createElement('span')
     span.classList.add('time-status', 'inline-block')
-    span.textContent = 'Time status'
+    span.textContent = @getTime()
     @appendChild(span)
 
   update: ->

--- a/lib/time-status-view.coffee
+++ b/lib/time-status-view.coffee
@@ -20,7 +20,8 @@ class TimeStatusView extends HTMLElement
     ), 1000
 
   getTime: ->
-    (new Date).toLocaleTimeString navigator.language,
+    language = atom.config.get('time-status.language') or navigator.language
+    (new Date).toLocaleTimeString language,
       hour: '2-digit'
       minute:'2-digit'
 

--- a/lib/time-status-view.coffee
+++ b/lib/time-status-view.coffee
@@ -16,13 +16,13 @@ class TimeStatusView extends HTMLElement
 
   update: ->
     setInterval ( =>
-      currentDate = new Date
-      currentTime = currentDate.getHours() + ":" + currentDate.getMinutes()
-      currentTime = currentTime.replace( /\b(\d)\b/g, "0$1" )
-      currentTime.replace /\s/g, ""
-
-      @time.textContent = currentTime
+      @time.textContent = @getTime()
     ), 1000
+
+  getTime: ->
+    (new Date).toLocaleTimeString navigator.language,
+      hour: '2-digit'
+      minute:'2-digit'
 
 module.exports = document.registerElement('time-status',
                                           prototype: TimeStatusView.prototype,


### PR DESCRIPTION
By default it uses `navigator.language`, and it can be overriden using 

```yml
"time-status":
    language: "en" # or "fr" for example
```